### PR TITLE
Use callback style interface to replace smart pointer

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -50,7 +50,7 @@ pub struct Ball {
     anim: Animation,
 }
 
-impl EntityType for Ball {
+impl EntType for Ball {
     fn load(eng: &mut Engine) -> Self {
         let size = Vec2::new(32., 32.0);
         let mut sheet = Sprite::with_sizef(load_texture(eng), size);
@@ -59,109 +59,125 @@ impl EntityType for Ball {
         Ball { size, anim }
     }
 
-    fn init(&mut self, _eng: &mut Engine, ent: &mut Entity) {
-        ent.size = self.size;
-        ent.anim = Some(self.anim.clone());
-        ent.group = EntityGroup::PROJECTILE;
-        ent.accel.y = -BALL_ACCEL * 2.0;
-        ent.friction = Vec2::splat(0.1);
-        ent.physics = EntityPhysics::LITE;
-        ent.restitution = 12.0;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|_, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.size = self.size;
+            ent.anim = Some(self.anim.clone());
+            ent.group = EntityGroup::PROJECTILE;
+            ent.accel.y = -BALL_ACCEL * 2.0;
+            ent.friction = Vec2::splat(0.1);
+            ent.physics = EntPhysics::LITE;
+            ent.restitution = 12.0;
+        });
     }
 
-    fn collide(
-        &mut self,
-        _eng: &mut Engine,
-        ent: &mut Entity,
-        normal: Vec2,
-        _trace: Option<&Trace>,
-    ) {
-        if normal.y != 0.0 {
-            ent.vel.y = normal.y * BALL_MAX_VEL;
-            ent.accel.y = normal.y * BALL_ACCEL;
-        }
-        if normal.x != 0.0 {
-            ent.vel.x = normal.x * BALL_MAX_VEL;
-            ent.accel.x = normal.x * BALL_ACCEL;
-        }
+    fn collide(&mut self, eng: &mut Engine, ent: EntRef, normal: Vec2, _trace: Option<&Trace>) {
+        eng.with_world(|_eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+
+            if normal.y != 0.0 {
+                ent.vel.y = normal.y * BALL_MAX_VEL;
+                ent.accel.y = normal.y * BALL_ACCEL;
+            }
+            if normal.x != 0.0 {
+                ent.vel.x = normal.x * BALL_MAX_VEL;
+                ent.accel.x = normal.x * BALL_ACCEL;
+            }
+        });
     }
 
-    fn post_update(&mut self, eng: &mut Engine, ent: &mut Entity) {
-        let view = eng.view_size();
-        let half_size = ent.size * 0.5;
-        let bounds = ent.bounds();
-        if bounds.max.x < 0.0 {
-            ent.pos.x = half_size.x;
-            ent.vel.x = BALL_MAX_VEL;
-        }
-        if bounds.min.x > view.x {
-            ent.pos.x = view.x - half_size.x;
-            ent.vel.x = -BALL_MAX_VEL;
-        }
-        if bounds.max.y < 0.0 {
-            ent.pos.y = half_size.y;
-            ent.vel.y = BALL_MAX_VEL;
-        }
-        if bounds.min.y > view.y {
-            ent.pos.y = view.y - half_size.y;
-            ent.vel.y = -BALL_MAX_VEL;
-        }
+    fn post_update(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            let view = eng.view_size();
+            let half_size = ent.size * 0.5;
+            let bounds = ent.bounds();
+            if bounds.max.x < 0.0 {
+                ent.pos.x = half_size.x;
+                ent.vel.x = BALL_MAX_VEL;
+            }
+            if bounds.min.x > view.x {
+                ent.pos.x = view.x - half_size.x;
+                ent.vel.x = -BALL_MAX_VEL;
+            }
+            if bounds.max.y < 0.0 {
+                ent.pos.y = half_size.y;
+                ent.vel.y = BALL_MAX_VEL;
+            }
+            if bounds.min.y > view.y {
+                ent.pos.y = view.y - half_size.y;
+                ent.vel.y = -BALL_MAX_VEL;
+            }
+        });
     }
 }
 
 #[derive(Clone)]
 pub struct LeftWall;
 
-impl EntityType for LeftWall {
+impl EntType for LeftWall {
     fn load(_eng: &mut Engine) -> Self {
         Self
     }
-    fn init(&mut self, eng: &mut Engine, ent: &mut Entity) {
-        ent.size = Vec2::new(WALL_THICK, eng.view_size().y);
-        ent.check_against = EntityGroup::PROJECTILE;
-        ent.physics = EntityPhysics::FIXED;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.size = Vec2::new(WALL_THICK, eng.view_size().y);
+            ent.check_against = EntityGroup::PROJECTILE;
+            ent.physics = EntPhysics::FIXED;
+        });
     }
 }
 
 #[derive(Clone)]
 pub struct RightWall;
 
-impl EntityType for RightWall {
+impl EntType for RightWall {
     fn load(_eng: &mut Engine) -> Self {
         Self
     }
-    fn init(&mut self, eng: &mut Engine, ent: &mut Entity) {
-        ent.size = Vec2::new(WALL_THICK, eng.view_size().y);
-        ent.check_against = EntityGroup::PROJECTILE;
-        ent.physics = EntityPhysics::FIXED;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.size = Vec2::new(WALL_THICK, eng.view_size().y);
+            ent.check_against = EntityGroup::PROJECTILE;
+            ent.physics = EntPhysics::FIXED;
+        });
     }
 }
 
 #[derive(Clone)]
 pub struct TopWall;
 
-impl EntityType for TopWall {
+impl EntType for TopWall {
     fn load(_eng: &mut Engine) -> Self {
         Self
     }
-    fn init(&mut self, eng: &mut Engine, ent: &mut Entity) {
-        ent.size = Vec2::new(eng.view_size().x, WALL_THICK);
-        ent.check_against = EntityGroup::PROJECTILE;
-        ent.physics = EntityPhysics::FIXED;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.size = Vec2::new(eng.view_size().x, WALL_THICK);
+            ent.check_against = EntityGroup::PROJECTILE;
+            ent.physics = EntPhysics::FIXED;
+        });
     }
 }
 
 #[derive(Clone)]
 pub struct BottomWall;
 
-impl EntityType for BottomWall {
+impl EntType for BottomWall {
     fn load(_eng: &mut Engine) -> Self {
         Self
     }
-    fn init(&mut self, eng: &mut Engine, ent: &mut Entity) {
-        ent.size = Vec2::new(eng.view_size().x, WALL_THICK);
-        ent.check_against = EntityGroup::PROJECTILE;
-        ent.physics = EntityPhysics::FIXED;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.size = Vec2::new(eng.view_size().x, WALL_THICK);
+            ent.check_against = EntityGroup::PROJECTILE;
+            ent.physics = EntPhysics::FIXED;
+        });
     }
 }
 
@@ -173,7 +189,7 @@ pub struct Brick {
     anim: Animation,
 }
 
-impl EntityType for Brick {
+impl EntType for Brick {
     fn load(eng: &mut Engine) -> Self {
         let mut sheet = Sprite::with_sizef(load_texture(eng), BRICK_SIZE);
         sheet.color = Color::rgb(0x5b, 0x6e, 0xe1);
@@ -186,51 +202,57 @@ impl EntityType for Brick {
         }
     }
 
-    fn init(&mut self, _eng: &mut Engine, ent: &mut Entity) {
-        ent.anim = Some(self.anim.clone());
-        ent.size = BRICK_SIZE;
-        ent.check_against = EntityGroup::PROJECTILE;
-        ent.physics = EntityPhysics::ACTIVE;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|_, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.anim = Some(self.anim.clone());
+            ent.size = BRICK_SIZE;
+            ent.check_against = EntityGroup::PROJECTILE;
+            ent.physics = EntPhysics::ACTIVE;
+        });
     }
 
-    fn kill(&mut self, _eng: &mut Engine, _ent: &mut Entity) {
+    fn kill(&mut self, _eng: &mut Engine, _ent: EntRef) {
         G.with_borrow_mut(|g| {
             g.score += 1;
         });
     }
 
-    fn update(&mut self, eng: &mut Engine, ent: &mut Entity) {
+    fn update(&mut self, eng: &mut Engine, ent: EntRef) {
         if self.hit {
             self.dying += eng.tick;
             if self.dying > BRICK_DYING {
-                eng.kill(ent.ent_ref);
+                eng.kill(ent);
             }
 
-            if let Some(anim) = ent.anim.as_mut() {
-                let progress = (self.dying / BRICK_DYING).powi(2);
-                let color = {
-                    let (r1, g1, b1): (u8, u8, u8) = (0x5b, 0x6e, 0xe1);
-                    let (r2, g2, b2) = (RED.r, RED.g, RED.b);
-                    let r = r1.saturating_add(((r1 as f32 - r2 as f32) * progress).abs() as u8);
-                    let g = g1.saturating_add(((g1 as f32 - g2 as f32) * progress).abs() as u8);
-                    let b = b1.saturating_add(((b1 as f32 - b2 as f32) * progress).abs() as u8);
-                    Color::rgb(r, g, b)
-                };
-                let scale = {
-                    let start = 1.0;
-                    let end = start * 0.5;
-                    start - (start - end) * progress
-                };
+            let progress = (self.dying / BRICK_DYING).powi(2);
+            let color = {
+                let (r1, g1, b1): (u8, u8, u8) = (0x5b, 0x6e, 0xe1);
+                let (r2, g2, b2) = (RED.r, RED.g, RED.b);
+                let r = r1.saturating_add(((r1 as f32 - r2 as f32) * progress).abs() as u8);
+                let g = g1.saturating_add(((g1 as f32 - g2 as f32) * progress).abs() as u8);
+                let b = b1.saturating_add(((b1 as f32 - b2 as f32) * progress).abs() as u8);
+                Color::rgb(r, g, b)
+            };
+            let scale = {
+                let start = 1.0;
+                let end = start * 0.5;
+                start - (start - end) * progress
+            };
+            eng.with_world(|_, mut w| {
+                let ent = w.get_mut(ent).unwrap();
                 ent.scale = Vec2::splat(scale);
-                anim.sheet.color = color;
-            }
+                if let Some(anim) = ent.anim.as_mut() {
+                    anim.sheet.color = color;
+                }
+            });
         }
     }
 
-    fn touch(&mut self, _eng: &mut Engine, ent: &mut Entity, _other: &mut Entity) {
+    fn touch(&mut self, eng: &mut Engine, ent: EntRef, _other: EntRef) {
         if !self.hit {
             self.hit = true;
-            self.dead_pos = ent.pos;
+            self.dead_pos = eng.with_world(|_, w| w.get(ent).unwrap().pos);
         }
     }
 }
@@ -241,7 +263,7 @@ pub struct Player {
     anim: Animation,
 }
 
-impl EntityType for Player {
+impl EntType for Player {
     fn load(eng: &mut Engine) -> Self {
         let size = Vec2::new(128.0, 48.0);
         let mut sheet = Sprite::with_sizef(load_texture(eng), size);
@@ -251,31 +273,43 @@ impl EntityType for Player {
         Self { size, anim }
     }
 
-    fn init(&mut self, _eng: &mut Engine, ent: &mut Entity) {
-        ent.size = self.size;
-        ent.anim = Some(self.anim.clone());
-        ent.friction = Vec2::splat(FRICTION);
-        ent.check_against = EntityGroup::PROJECTILE;
-        ent.physics = EntityPhysics::ACTIVE;
+    fn init(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|_, mut w| {
+            let ent = w.get_mut(ent).unwrap();
+            ent.size = self.size;
+            ent.anim = Some(self.anim.clone());
+            ent.friction = Vec2::splat(FRICTION);
+            ent.check_against = EntityGroup::PROJECTILE;
+            ent.physics = EntPhysics::ACTIVE;
+        });
     }
 
-    fn update(&mut self, eng: &mut Engine, ent: &mut Entity) {
-        let input = eng.input();
+    fn update(&mut self, eng: &mut Engine, ent: EntRef) {
+        eng.with_world(|eng, mut w| {
+            let ent = w.get_mut(ent).unwrap();
 
-        ent.accel = Vec2::default();
-        if input.pressed(Action::Right) {
-            ent.vel.x = PLAYER_VEL;
-        }
-        if input.pressed(Action::Left) {
-            ent.vel.x = -PLAYER_VEL;
-        }
+            let input = eng.input();
+
+            ent.accel = Vec2::default();
+            if input.pressed(Action::Right) {
+                ent.vel.x = PLAYER_VEL;
+            }
+            if input.pressed(Action::Left) {
+                ent.vel.x = -PLAYER_VEL;
+            }
+        });
     }
 
-    fn touch(&mut self, _eng: &mut Engine, ent: &mut Entity, other: &mut Entity) {
-        if other.ent_type.is::<Ball>() {
-            other.vel.x = (other.vel.x * 0.5 + ent.vel.x).clamp(-BALL_MAX_VEL, BALL_MAX_VEL);
-            other.accel.x = other.vel.normalize().x * other.accel.x.abs();
-        }
+    fn touch(&mut self, eng: &mut Engine, ent: EntRef, other: EntRef) {
+        eng.with_world(|_, mut w| {
+            let [Some(ent), Some(other)] = w.get_many_mut([ent, other]) else {
+                return;
+            };
+            if other.ent_type.is::<Ball>() {
+                other.vel.x = (other.vel.x * 0.5 + ent.vel.x).clamp(-BALL_MAX_VEL, BALL_MAX_VEL);
+                other.accel.x = other.vel.normalize().x * other.accel.x.abs();
+            }
+        });
     }
 }
 
@@ -395,13 +429,13 @@ fn setup(eng: &mut Engine) {
         height: true,
     });
     eng.set_sweep_axis(SweepAxis::Y);
-    eng.add_entity_type::<Player>();
-    eng.add_entity_type::<LeftWall>();
-    eng.add_entity_type::<RightWall>();
-    eng.add_entity_type::<TopWall>();
-    eng.add_entity_type::<BottomWall>();
-    eng.add_entity_type::<Ball>();
-    eng.add_entity_type::<Brick>();
+    eng.add_ent_type::<Player>();
+    eng.add_ent_type::<LeftWall>();
+    eng.add_ent_type::<RightWall>();
+    eng.add_ent_type::<TopWall>();
+    eng.add_ent_type::<BottomWall>();
+    eng.add_ent_type::<Ball>();
+    eng.add_ent_type::<Brick>();
     eng.set_scene(Demo::default());
 }
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,6 +1,4 @@
-use glam::Vec2;
-
-use crate::{render::Render, sprite::Sprite};
+use crate::sprite::Sprite;
 
 #[derive(Clone)]
 pub struct Animation {
@@ -10,14 +8,5 @@ pub struct Animation {
 impl Animation {
     pub fn new(sheet: Sprite) -> Self {
         Self { sheet }
-    }
-    pub(crate) fn draw(
-        &mut self,
-        render: &mut Render,
-        pos: Vec2,
-        scale: Option<Vec2>,
-        angle: Option<f32>,
-    ) {
-        render.draw_image(&self.sheet, pos, scale, angle)
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,8 +1,8 @@
 use glam::Vec2;
 
 use crate::{
-    entity::{Entity, EntityRef},
-    types::{Mut, Rect},
+    entity::{Ent, EntRef},
+    types::Rect,
 };
 
 #[derive(Default)]
@@ -41,7 +41,7 @@ pub struct Camera {
     // Internal state
     deadzone_pos: Vec2,
     look_ahead_target: Vec2,
-    pub(crate) follow: Option<EntityRef>,
+    pub(crate) follow: Option<EntRef>,
     pos: Vec2,
     vel: Vec2,
     snap: bool,
@@ -66,11 +66,10 @@ impl Camera {
         &mut self,
         tick: f32,
         screen_size: Vec2,
-        follow: Option<Mut<Entity>>,
+        follow: Option<&Ent>,
         bounds: Option<Vec2>,
     ) {
         if let Some(follow) = follow {
-            let follow = follow.borrow();
             let follow_size = follow.scaled_size();
             let size = Vec2::new(
                 follow_size.x.min(self.deadzone.x),
@@ -124,7 +123,7 @@ impl Camera {
         self.pos = pos;
     }
 
-    pub fn follow(&mut self, entity_ref: EntityRef, snap: bool) {
+    pub fn follow(&mut self, entity_ref: EntRef, snap: bool) {
         self.follow.replace(entity_ref);
         self.snap = snap;
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,9 @@
 use std::any::Any;
 
+use glam::Vec2;
 use serde_json::Value;
 
-use crate::entity::EntityRef;
+use crate::{entity::EntRef, trace::Trace};
 
 #[derive(Default)]
 pub(crate) struct Commands {
@@ -20,25 +21,29 @@ impl Commands {
 }
 
 pub(crate) enum Command {
+    Collide {
+        ent: EntRef,
+        normal: Vec2,
+        trace: Option<Trace>,
+    },
     Setting {
-        ent: EntityRef,
+        ent: EntRef,
         settings: Value,
     },
     KillEntity {
-        ent: EntityRef,
+        ent: EntRef,
     },
     Damage {
-        ent: EntityRef,
-        by_ent: EntityRef,
+        ent: EntRef,
+        by_ent: EntRef,
         damage: f32,
     },
     Trigger {
-        ent: EntityRef,
-        other: EntityRef,
+        ent: EntRef,
+        other: EntRef,
     },
     Message {
-        ent: EntityRef,
-        msg_id: u32,
+        ent: EntRef,
         data: Box<dyn Any>,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,4 @@ pub mod sorts;
 pub mod sprite;
 pub mod trace;
 pub mod types;
+pub mod world;

--- a/src/platform/sdl.rs
+++ b/src/platform/sdl.rs
@@ -203,6 +203,7 @@ impl Platform for SDLPlatform {
         engine.init();
         engine
             .render
+            .borrow_mut()
             .resize(event_handler.window.drawable_size().into());
 
         while !event_handler.wants_to_exit {
@@ -212,13 +213,13 @@ impl Platform for SDLPlatform {
             event_handler
                 .pump_events(&mut engine)
                 .map_err(|err| anyhow!(err))?;
-            engine.platform_mut().prepare_frame();
+            engine.with_platform(|p| p.prepare_frame());
             engine.update();
-            engine.platform_mut().end_frame();
+            engine.with_platform(|p| p.end_frame());
         }
 
         engine.cleanup();
-        engine.platform_mut().cleanup();
+        engine.with_platform(|p| p.cleanup());
 
         Ok(())
     }
@@ -375,7 +376,7 @@ impl SDLEventHandler {
                         WindowEvent::SizeChanged(..) | WindowEvent::Resized(..)
                     ) {
                         let size = self.window.drawable_size();
-                        engine.render.resize(size.into());
+                        engine.render.borrow_mut().resize(size.into());
                     }
                 }
                 _ => {}

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -413,7 +413,7 @@ impl Platform for WebPlatform {
         setup(&mut engine);
         engine.init();
 
-        engine.render.resize(size);
+        engine.render.borrow_mut().resize(size);
 
         loop {
             if let Err(err) = engine.handle_assets().await {
@@ -421,9 +421,9 @@ impl Platform for WebPlatform {
             }
             // handle events
             handle_events(&mut engine, &mut events_receiver);
-            engine.platform_mut().prepare_frame();
+            engine.with_platform(|p| p.prepare_frame());
             engine.update();
-            engine.platform_mut().end_frame();
+            engine.with_platform(|p| p.end_frame());
             wait_next_frame().await.unwrap();
         }
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,7 @@ pub use crate::collision_map::CollisionMap;
 pub use crate::color::*;
 pub use crate::engine::{Engine, Scene};
 pub use crate::entity::{
-    Entity, EntityCollidesMode, EntityGroup, EntityPhysics, EntityRef, EntityType, EntityTypeId,
+    Ent, EntCollidesMode, EntPhysics, EntRef, EntType, EntTypeId, EntityGroup,
 };
 pub use crate::font::{Font, Text};
 pub use crate::input::{ActionId, KeyCode, KeyState};
@@ -12,6 +12,6 @@ pub use crate::map::Map;
 pub use crate::render::{ResizeMode, ScaleMode};
 pub use crate::sprite::Sprite;
 pub use crate::trace::Trace;
-pub use crate::types::{Mut, Rect, SweepAxis, Vec2};
+pub use crate::types::{Rect, SweepAxis, Vec2};
 pub use anyhow::{self, Error, Result};
 pub use glam;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -2,7 +2,7 @@ use glam::{IVec2, Vec2};
 
 use crate::prelude::CollisionMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Trace {
     // The tile that was hit. 0 if no hit.
     pub tile: i32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,3 @@
-use std::{
-    cell::{Ref, RefCell, RefMut},
-    rc::Rc,
-};
-
-use anyhow::Result;
 pub use glam::Vec2;
 
 /// Rect
@@ -13,48 +7,12 @@ pub struct Rect {
     pub max: Vec2,
 }
 
-/// A mutable reference
-pub struct Mut<T: ?Sized>(Rc<RefCell<T>>);
-
-impl<T: ?Sized> From<Rc<RefCell<T>>> for Mut<T> {
-    fn from(value: Rc<RefCell<T>>) -> Self {
-        Self(value)
-    }
-}
-
-impl<T> Mut<T> {
-    pub fn new(v: T) -> Mut<T> {
-        Self(Rc::new(RefCell::new(v)))
-    }
-}
-
-impl<T: ?Sized> Mut<T> {
-    #[cfg_attr(feature = "debug_mut", track_caller)]
-    pub fn borrow(&self) -> Ref<'_, T> {
-        self.0.borrow()
-    }
-
-    #[cfg_attr(feature = "debug_mut", track_caller)]
-    pub fn borrow_mut(&self) -> RefMut<'_, T> {
-        self.0.borrow_mut()
-    }
-
-    #[cfg_attr(feature = "debug_mut", track_caller)]
-    pub fn try_borrow(&self) -> Result<Ref<'_, T>> {
-        let r = self.0.try_borrow()?;
-        Ok(r)
-    }
-
-    #[cfg_attr(feature = "debug_mut", track_caller)]
-    pub fn try_borrow_mut(&self) -> Result<RefMut<'_, T>> {
-        let r = self.0.try_borrow_mut()?;
-        Ok(r)
-    }
-}
-
-impl<T: ?Sized> Clone for Mut<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+impl Rect {
+    pub(crate) fn is_touching(&self, other: &Self) -> bool {
+        !(self.min.x > other.max.x
+            || self.max.x < other.min.x
+            || self.min.y > other.max.y
+            || self.max.y < other.min.y)
     }
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,0 +1,220 @@
+use std::{any::type_name, cell::UnsafeCell, collections::HashMap, rc::Rc};
+
+use crate::{
+    entity::{Ent, EntRef, EntType, EntTypeId},
+    sorts::insertion_sort_by_key,
+    types::SweepAxis,
+};
+
+/// A mutable reference
+pub(crate) struct Mut<T: ?Sized>(UnsafeCell<T>);
+
+impl<T> Mut<T> {
+    pub(crate) fn new(v: T) -> Mut<T> {
+        Self(UnsafeCell::new(v))
+    }
+}
+
+impl<T: ?Sized> Mut<T> {
+    pub(crate) unsafe fn get(&self) -> &T {
+        self.0.get().as_ref().unwrap()
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) unsafe fn get_mut(&self) -> &mut T {
+        self.0.get().as_mut().unwrap()
+    }
+}
+
+/// World contains entities
+#[derive(Default)]
+pub struct World {
+    /// Unique id counter
+    unique_id: u16,
+    /// This field may be reorder
+    entities: Vec<EntRef>,
+    /// Allocated entities count
+    alloced: usize,
+    /// Fixed storage of entities, the index is unchanged
+    entities_storage: Vec<Mut<Ent>>,
+    /// Entity Types
+    entity_types: HashMap<EntTypeId, Rc<dyn EntType>>,
+    /// Name to Entity Types
+    name_to_entity_types: HashMap<String, EntTypeId>,
+}
+
+impl World {
+    /// Get an entity type instance
+    pub(crate) fn get_ent_type_instance(&self, type_id: &EntTypeId) -> Option<Box<dyn EntType>> {
+        self.entity_types.get(type_id).map(|ent_type| {
+            let t = ent_type.as_ref();
+            dyn_clone::clone_box(t)
+        })
+    }
+
+    pub(crate) fn add_ent_type<T: EntType + Clone + 'static>(&mut self, ent_type: Rc<dyn EntType>) {
+        let type_id = EntTypeId::of::<T>();
+        self.entity_types.insert(type_id.clone(), ent_type);
+        let name = type_name::<T>()
+            .split("::")
+            .last()
+            .expect("can't get name of entity type");
+        self.name_to_entity_types.insert(name.to_string(), type_id);
+    }
+
+    pub(crate) fn get_type_id_by_name(&self, name: &str) -> Option<&EntTypeId> {
+        self.name_to_entity_types.get(name)
+    }
+
+    pub(crate) fn next_unique_id(&self) -> u16 {
+        self.unique_id
+    }
+
+    pub(crate) fn alloced(&self) -> usize {
+        self.alloced
+    }
+
+    /// Get an entity by ref
+    pub(crate) fn get_nth(&self, n: usize) -> Option<&EntRef> {
+        self.entities.get(n)
+    }
+
+    /// Get an entity by ref
+    pub(crate) fn swap_remove(&mut self, n: usize) {
+        self.entities.swap_remove(n);
+        self.alloced -= 1;
+    }
+
+    pub(crate) fn sort_entities_for_sweep(&mut self, sweep_axis: SweepAxis) {
+        let mut entities = core::mem::take(&mut self.entities);
+        insertion_sort_by_key(&mut entities, |ent_ref| {
+            let ent_bounds = self.get(*ent_ref).unwrap().bounds();
+            sweep_axis.get(ent_bounds.min) as usize
+        });
+        let _ = core::mem::replace(&mut self.entities, entities);
+    }
+
+    /// Get an entity by ref
+    pub(crate) fn get_unchecked(&self, ent_ref: EntRef) -> Option<&Ent> {
+        self.entities_storage
+            .get(ent_ref.index as usize)
+            .map(|ent| unsafe { ent.get() })
+    }
+
+    /// Get an entity by ref
+    pub fn get(&self, ent_ref: EntRef) -> Option<&Ent> {
+        if let Some(ent) = self.entities_storage.get(ent_ref.index as usize) {
+            let ent = unsafe { ent.get() };
+            if ent.is_valid(ent_ref) {
+                return Some(ent);
+            }
+        }
+        None
+    }
+
+    /// Get an entity by ref
+    pub fn get_mut(&mut self, ent_ref: EntRef) -> Option<&mut Ent> {
+        if let Some(ent) = self.entities_storage.get(ent_ref.index as usize) {
+            let ent = unsafe { ent.get_mut() };
+            if ent.is_valid(ent_ref) {
+                return Some(ent);
+            }
+        }
+        None
+    }
+
+    /// Get an entity by ref
+    pub fn get_many<const N: usize>(&self, ent_refs: [EntRef; N]) -> [Option<&Ent>; N] {
+        ent_refs.map(|ent_ref| {
+            if let Some(ent) = self.entities_storage.get(ent_ref.index as usize) {
+                let ent = unsafe { ent.get() };
+                if ent.is_valid(ent_ref) {
+                    return Some(ent);
+                }
+            }
+            None
+        })
+    }
+
+    /// Get an entity by ref
+    pub fn get_many_mut<const N: usize>(&mut self, ent_refs: [EntRef; N]) -> [Option<&mut Ent>; N] {
+        ent_refs.map(|ent_ref| {
+            if let Some(ent) = self.entities_storage.get(ent_ref.index as usize) {
+                let ent = unsafe { ent.get_mut() };
+                if ent.is_valid(ent_ref) {
+                    return Some(ent);
+                }
+            }
+            None
+        })
+    }
+
+    /// Get an entity by ref
+    pub fn many<const N: usize>(&self, ent_refs: [EntRef; N]) -> [&Ent; N] {
+        ent_refs.map(|ent_ref| {
+            let ent = self
+                .entities_storage
+                .get(ent_ref.index as usize)
+                .expect("ent");
+            let ent = unsafe { ent.get() };
+            if !ent.is_valid(ent_ref) {
+                panic!("invalid ent");
+            }
+            ent
+        })
+    }
+
+    /// Get an entity by ref
+    pub fn many_mut<const N: usize>(&mut self, ent_refs: [EntRef; N]) -> [&mut Ent; N] {
+        ent_refs.map(|ent_ref| {
+            let ent = self
+                .entities_storage
+                .get(ent_ref.index as usize)
+                .expect("ent");
+            let ent = unsafe { ent.get_mut() };
+            if !ent.is_valid(ent_ref) {
+                panic!("invalid ent");
+            }
+            ent
+        })
+    }
+
+    /// Get an entity by ref
+    pub fn entities(&self) -> impl Iterator<Item = &Ent> {
+        self.entities
+            .iter()
+            .take(self.alloced)
+            .filter_map(|ent_ref| self.get(*ent_ref))
+    }
+
+    /// Spawn a new entity
+    pub(crate) fn spawn(&mut self, mut ent: Ent) -> EntRef {
+        let id = self.unique_id;
+        assert_eq!(ent.ent_ref.id, id, "expect unique_id");
+
+        let index: u16;
+        if self.entities.len() > self.alloced {
+            // reuse slot
+            index = self.entities[self.alloced].index;
+            ent.ent_ref.index = index;
+            self.entities_storage[index as usize] = Mut::new(ent);
+        } else {
+            // alloc slot
+            index = self.entities_storage.len() as u16;
+            ent.ent_ref.index = index;
+            self.entities.push(ent.ent_ref);
+            self.entities_storage.push(Mut::new(ent));
+            self.alloced += 1;
+        };
+
+        self.unique_id += 1;
+
+        EntRef { id, index }
+    }
+
+    pub(crate) fn reset_entities(&mut self) {
+        self.entities.clear();
+        self.entities_storage.clear();
+        self.alloced = 0;
+    }
+}


### PR DESCRIPTION
All entities are stored in World.

The smart pointer `Guard<T>` style makes lifetime unmanageable when access multiple entities simutaneously.
Use callback style to access world can force lifetime been kept in a small scope. [gpui](https://zed.dev/blog/gpui-ownership) also use this style.

The method to access multiple Entities while using `mut` ref to avoid data race is inspired by [Bevy World API](https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.World.html#method.get_many_entities)